### PR TITLE
Organize symbols into a tree

### DIFF
--- a/shared/src/main/scala/tastyquery/Contexts.scala
+++ b/shared/src/main/scala/tastyquery/Contexts.scala
@@ -1,46 +1,94 @@
 package tastyquery
 
 import dotty.tools.tasty.TastyBuffer.Addr
-import tastyquery.ast.Names.Name
-import tastyquery.ast.Symbols.{ClassSymbol, NoSymbol, PackageClassSymbol, Symbol}
+import dotty.tools.tasty.TastyFormat.NameTags
+import tastyquery.ast.Names.{Name, QualifiedName, RootName, SimpleName, TermName}
+import tastyquery.ast.Symbols.*
 import tastyquery.ast.Types.TypeLambda
 
 import scala.collection.mutable
 import scala.collection.mutable.HashMap
 
 object Contexts {
+  val rootPackage = PackageClassSymbol(RootName, NoSymbol)
 
   /** The current context */
   inline def ctx(using ctx: Context): Context = ctx
 
-  def empty: Context = new Context()
+  def empty: Context = new Context(rootPackage)
 
-  class Context(val localSymbols: HashMap[Addr, Symbol] = new mutable.HashMap[Addr, Symbol]()) {
+  class Context(
+    val owner: DeclaringSymbol,
+    val localSymbols: HashMap[Addr, Symbol] = new mutable.HashMap[Addr, Symbol]()
+  ) {
     var enclosingLambdas: Map[Addr, TypeLambda] = Map.empty
 
     def withEnclosingLambda(addr: Addr, tl: TypeLambda): Context = {
-      val copy = new Context(localSymbols)
+      val copy = new Context(owner, localSymbols)
       copy.enclosingLambdas = enclosingLambdas.updated(addr, tl)
       copy
     }
 
+    def withOwner(newOwner: DeclaringSymbol): Context =
+      if (newOwner == owner) this
+      else new Context(newOwner, localSymbols)
+
     def hasSymbolAt(addr: Addr): Boolean = localSymbols.contains(addr)
 
-    def registerSym(addr: Addr, sym: Symbol): Unit =
+    def registerSym(addr: Addr, sym: Symbol): Unit = {
       localSymbols(addr) = sym
+      owner.addDecl(sym)
+    }
 
-    def createSymbolIfNew(addr: Addr, name: Name): Unit =
+    def createSymbolIfNew(addr: Addr, name: Name): Symbol = {
       if (!hasSymbolAt(addr)) {
-        registerSym(addr, new Symbol(name))
+        registerSym(addr, new Symbol(name, owner))
+      }
+      localSymbols(addr)
+    }
+
+    def createClassSymbolIfNew(addr: Addr, name: Name): ClassSymbol = {
+      if (!hasSymbolAt(addr)) {
+        registerSym(addr, new ClassSymbol(name, owner))
+      }
+      localSymbols(addr).asInstanceOf[ClassSymbol]
+    }
+
+    def createMethodSymbolIfNew(addr: Addr, name: TermName): MethodSymbol = {
+      if (!hasSymbolAt(addr)) {
+        registerSym(addr, new MethodSymbol(name, owner))
+      }
+      localSymbols(addr).asInstanceOf[MethodSymbol]
+    }
+
+    def createPackageSymbolIfNew(name: TermName): PackageClassSymbol = {
+      def create(): PackageClassSymbol = {
+        val sym = new PackageClassSymbol(name, owner)
+        owner.addDecl(sym)
+        sym
       }
 
-    def createClassSymbolIfNew(addr: Addr, name: Name): Unit =
-      if (!hasSymbolAt(addr)) {
-        registerSym(addr, new ClassSymbol(name))
+      getPackageSymbol(name) match {
+        case Some(pkg) => pkg
+        case None =>
+          name match {
+            case _: SimpleName => create()
+            case QualifiedName(NameTags.QUALIFIED, prefix, _) =>
+              if (prefix == owner.name) {
+                create()
+              } else {
+                // create intermediate packages
+                val newOwner = createPackageSymbolIfNew(prefix)
+                withOwner(newOwner).createPackageSymbolIfNew(name)
+              }
+            case _ =>
+              throw IllegalArgumentException(s"Unexpected package name: $name")
+          }
       }
+    }
 
-    // TODO: store decls and walk the decls tree, finding a symbol for a package
-    def createPackageSymbolIfNew(name: Name): PackageClassSymbol =
-      new PackageClassSymbol(name)
+    def getPackageSymbol(name: TermName): Option[PackageClassSymbol] = rootPackage.findPackageSymbol(name)
+
+    def getSymbol(addr: Addr): Symbol = localSymbols(addr)
   }
 }

--- a/shared/src/main/scala/tastyquery/Contexts.scala
+++ b/shared/src/main/scala/tastyquery/Contexts.scala
@@ -2,7 +2,7 @@ package tastyquery
 
 import dotty.tools.tasty.TastyBuffer.Addr
 import dotty.tools.tasty.TastyFormat.NameTags
-import tastyquery.ast.Names.{Name, QualifiedName, RootName, SimpleName, TermName}
+import tastyquery.ast.Names.*
 import tastyquery.ast.Symbols.*
 import tastyquery.ast.Types.TypeLambda
 
@@ -66,8 +66,8 @@ object Contexts {
 
     def createPackageSymbolIfNew(name: TermName): PackageClassSymbol = {
       def create(): PackageClassSymbol = {
-        val sym = new PackageClassSymbol(name, owner)
-        owner.addDecl(sym)
+        val trueOwner = if (owner == defn.EmptyPackage) defn.RootPackage else owner
+        val sym       = new PackageClassSymbol(name, trueOwner)
         sym
       }
 

--- a/shared/src/main/scala/tastyquery/Contexts.scala
+++ b/shared/src/main/scala/tastyquery/Contexts.scala
@@ -17,7 +17,7 @@ object Contexts {
 
   def empty: Context = new Context(rootPackage)
 
-  class Context(
+  class Context private[Contexts] (
     val owner: DeclaringSymbol,
     val localSymbols: HashMap[Addr, Symbol] = new mutable.HashMap[Addr, Symbol]()
   ) {

--- a/shared/src/main/scala/tastyquery/Contexts.scala
+++ b/shared/src/main/scala/tastyquery/Contexts.scala
@@ -40,7 +40,7 @@ object Contexts {
       }
 
     // TODO: store decls and walk the decls tree, finding a symbol for a package
-    def createPackageSymbolIfNew(name: Name): Unit =
+    def createPackageSymbolIfNew(name: Name): PackageClassSymbol =
       new PackageClassSymbol(name)
   }
 }

--- a/shared/src/main/scala/tastyquery/Contexts.scala
+++ b/shared/src/main/scala/tastyquery/Contexts.scala
@@ -2,7 +2,7 @@ package tastyquery
 
 import dotty.tools.tasty.TastyBuffer.Addr
 import tastyquery.ast.Names.Name
-import tastyquery.ast.Symbols.{NoSymbol, Symbol}
+import tastyquery.ast.Symbols.{ClassSymbol, NoSymbol, PackageClassSymbol, Symbol}
 import tastyquery.ast.Types.TypeLambda
 
 import scala.collection.mutable
@@ -36,7 +36,11 @@ object Contexts {
 
     def createClassSymbolIfNew(addr: Addr, name: Name): Unit =
       if (!hasSymbolAt(addr)) {
-        registerSym(addr, new Symbol(name))
+        registerSym(addr, new ClassSymbol(name))
       }
+
+    // TODO: store decls and walk the decls tree, finding a symbol for a package
+    def createPackageSymbolIfNew(name: Name): Unit =
+      new PackageClassSymbol(name)
   }
 }

--- a/shared/src/main/scala/tastyquery/Definitions.scala
+++ b/shared/src/main/scala/tastyquery/Definitions.scala
@@ -1,8 +1,9 @@
 package tastyquery
 
-import tastyquery.ast.Names.RootName
+import tastyquery.ast.Names.{RootName, EmptyPackageName}
 import tastyquery.ast.Symbols.PackageClassSymbol
 
 class Definitions {
-  val RootPackage = PackageClassSymbol(RootName, null)
+  val RootPackage  = PackageClassSymbol(RootName, null)
+  val EmptyPackage = PackageClassSymbol(EmptyPackageName, RootPackage)
 }

--- a/shared/src/main/scala/tastyquery/Definitions.scala
+++ b/shared/src/main/scala/tastyquery/Definitions.scala
@@ -1,0 +1,8 @@
+package tastyquery
+
+import tastyquery.ast.Names.RootName
+import tastyquery.ast.Symbols.{NoSymbol, PackageClassSymbol}
+
+class Definitions {
+  val RootPackage = PackageClassSymbol(RootName, NoSymbol)
+}

--- a/shared/src/main/scala/tastyquery/Definitions.scala
+++ b/shared/src/main/scala/tastyquery/Definitions.scala
@@ -1,8 +1,8 @@
 package tastyquery
 
 import tastyquery.ast.Names.RootName
-import tastyquery.ast.Symbols.{NoSymbol, PackageClassSymbol}
+import tastyquery.ast.Symbols.PackageClassSymbol
 
 class Definitions {
-  val RootPackage = PackageClassSymbol(RootName, NoSymbol)
+  val RootPackage = PackageClassSymbol(RootName, null)
 }

--- a/shared/src/main/scala/tastyquery/Definitions.scala~2e44d26 (Link root package symbol's lifetime to context's lifetime)
+++ b/shared/src/main/scala/tastyquery/Definitions.scala~2e44d26 (Link root package symbol's lifetime to context's lifetime)
@@ -1,0 +1,8 @@
+package tastyquery
+
+import tastyquery.ast.Names.{EmptyPackageName, RootName}
+import tastyquery.ast.Symbols.{NoSymbol, PackageClassSymbol}
+
+class Definitions {
+  val RootPackage  = PackageClassSymbol(RootName, NoSymbol)
+}

--- a/shared/src/main/scala/tastyquery/ast/Names.scala
+++ b/shared/src/main/scala/tastyquery/ast/Names.scala
@@ -9,10 +9,11 @@ import scala.io.Codec
 object Names {
 
   /** The term name represented by the empty string */
-  val EmptyTermName: SimpleName = SimpleName("")
-  val EmptyTypeName: TypeName   = TypeName(EmptyTermName)
-  val RootName: SimpleName      = SimpleName("<root>")
-  val Wildcard: SimpleName      = SimpleName("_")
+  val EmptyTermName: SimpleName    = SimpleName("")
+  val EmptyTypeName: TypeName      = TypeName(EmptyTermName)
+  val RootName: SimpleName         = SimpleName("<root>")
+  val EmptyPackageName: SimpleName = SimpleName("<empty>")
+  val Wildcard: SimpleName         = SimpleName("_")
 
   val SuperAccessorPrefix: String  = "super$"
   val InlineAccessorPrefix: String = "inline$"

--- a/shared/src/main/scala/tastyquery/ast/Names.scala
+++ b/shared/src/main/scala/tastyquery/ast/Names.scala
@@ -9,10 +9,10 @@ import scala.io.Codec
 object Names {
 
   /** The term name represented by the empty string */
-  val EmptyTermName: SimpleName = SimpleName("")
-  val EmptyTypeName: TypeName   = TypeName(EmptyTermName)
-  val RootName: SimpleName      = SimpleName("<root>")
-  val Wildcard: SimpleName      = SimpleName("_")
+  val EmptyTermName: SimpleName    = SimpleName("")
+  val EmptyTypeName: TypeName      = TypeName(EmptyTermName)
+  val RootName: SimpleName         = SimpleName("<root>")
+  val Wildcard: SimpleName         = SimpleName("_")
 
   val SuperAccessorPrefix: String  = "super$"
   val InlineAccessorPrefix: String = "inline$"

--- a/shared/src/main/scala/tastyquery/ast/Names.scala
+++ b/shared/src/main/scala/tastyquery/ast/Names.scala
@@ -9,10 +9,10 @@ import scala.io.Codec
 object Names {
 
   /** The term name represented by the empty string */
-  val EmptyTermName: SimpleName    = SimpleName("")
-  val EmptyTypeName: TypeName      = TypeName(EmptyTermName)
-  val RootName: SimpleName         = SimpleName("<root>")
-  val Wildcard: SimpleName         = SimpleName("_")
+  val EmptyTermName: SimpleName = SimpleName("")
+  val EmptyTypeName: TypeName   = TypeName(EmptyTermName)
+  val RootName: SimpleName      = SimpleName("<root>")
+  val Wildcard: SimpleName      = SimpleName("_")
 
   val SuperAccessorPrefix: String  = "super$"
   val InlineAccessorPrefix: String = "inline$"

--- a/shared/src/main/scala/tastyquery/ast/Symbols.scala
+++ b/shared/src/main/scala/tastyquery/ast/Symbols.scala
@@ -1,11 +1,14 @@
 package tastyquery.ast
 
-import tastyquery.ast.Names.{Name, TypeName}
+import scala.collection.mutable
+import tastyquery.ast.Names._
+
+import dotty.tools.tasty.TastyFormat.NameTags
 
 object Symbols {
-  val NoSymbol = new Symbol(Names.EmptyTermName)
+  val NoSymbol = new Symbol(Names.EmptyTermName, null)
 
-  class Symbol(val name: Name) {
+  class Symbol(val name: Name, val owner: Symbol) {
     override def toString: String = s"symbol[$name]"
   }
 
@@ -13,7 +16,33 @@ object Symbols {
     def unapply(s: Symbol): Option[Name] = Some(s.name)
   }
 
-  class ClassSymbol(override val name: Name) extends Symbol(name)
+  abstract class DeclaringSymbol(override val name: Name, override val owner: Symbol) extends Symbol(name, owner) {
+    /* A map from the name of a declaration directly inside this symbol to the corresponding symbol
+     * The qualifiers on the name are not dropped. For instance, the package names are always fully qualified. */
+    protected val declarations: mutable.HashMap[Name, Symbol] = mutable.HashMap[Name, Symbol]()
 
-  class PackageClassSymbol(override val name: Name) extends ClassSymbol(name)
+    def addDecl(decl: Symbol): Unit         = declarations(decl.name) = decl
+    def getDecl(name: Name): Option[Symbol] = declarations.get(name)
+  }
+
+  class MethodSymbol(override val name: TermName, override val owner: Symbol) extends DeclaringSymbol(name, owner)
+
+  class ClassSymbol(override val name: Name, override val owner: Symbol) extends DeclaringSymbol(name, owner)
+
+  // TODO: typename or term name?
+  class PackageClassSymbol(override val name: Name, override val owner: Symbol) extends ClassSymbol(name, owner) {
+    def findPackageSymbol(packageName: TermName): Option[PackageClassSymbol] = packageName match {
+      case _: SimpleName => getPackageDecl(packageName)
+      case QualifiedName(NameTags.QUALIFIED, prefix, suffix) =>
+        if (prefix == name)
+          getPackageDecl(packageName)
+        else
+          // recurse
+          findPackageSymbol(prefix).flatMap(_.findPackageSymbol(packageName))
+      case _ => throw IllegalArgumentException(s"Unexpected package name: $name")
+    }
+
+    private def getPackageDecl(packageName: TermName): Option[PackageClassSymbol] =
+      getDecl(packageName).map(_.asInstanceOf[PackageClassSymbol])
+  }
 }

--- a/shared/src/main/scala/tastyquery/ast/Symbols.scala
+++ b/shared/src/main/scala/tastyquery/ast/Symbols.scala
@@ -4,8 +4,6 @@ import tastyquery.ast.Names.{Name, TypeName}
 
 object Symbols {
   val NoSymbol = new Symbol(Names.EmptyTermName)
-  // A placeholder for symbols that are not correctly created by tasty-query
-  val DummySymbol = new Symbol(Names.EmptyTermName)
 
   class Symbol(val name: Name) {
     override def toString: String = s"symbol[$name]"

--- a/shared/src/main/scala/tastyquery/ast/Symbols.scala
+++ b/shared/src/main/scala/tastyquery/ast/Symbols.scala
@@ -18,6 +18,13 @@ object Symbols {
 
   abstract class DeclaringSymbol(override val name: Name, override val owner: DeclaringSymbol)
       extends Symbol(name, owner) {
+    if (owner != null) {
+      // Declaring symbol is always a declaration in its owner
+      owner.addDecl(this)
+    } else {
+      // Root package is the only symbol that is allowed to not have an owner
+      assert(name == RootName)
+    }
     /* A map from the name of a declaration directly inside this symbol to the corresponding symbol
      * The qualifiers on the name are not dropped. For instance, the package names are always fully qualified. */
     protected val declarations: mutable.HashMap[Name, Symbol] = mutable.HashMap[Name, Symbol]()

--- a/shared/src/main/scala/tastyquery/ast/Symbols.scala
+++ b/shared/src/main/scala/tastyquery/ast/Symbols.scala
@@ -16,4 +16,6 @@ object Symbols {
   }
 
   class ClassSymbol(override val name: Name) extends Symbol(name)
+
+  class PackageClassSymbol(override val name: Name) extends ClassSymbol(name)
 }

--- a/shared/src/main/scala/tastyquery/ast/Trees.scala
+++ b/shared/src/main/scala/tastyquery/ast/Trees.scala
@@ -74,7 +74,13 @@ object Trees {
   case class Ident(name: TermName) extends Tree
 
   /** reference to a package, seen as a term */
-  class ReferencedPackage(override val name: TermName) extends Ident(name)
+  class ReferencedPackage(override val name: TermName) extends Ident(name) {
+    override def toString: String = s"ReferencedPackage($name)"
+  }
+
+  object ReferencedPackage {
+    def unapply(r: ReferencedPackage): Option[TermName] = Some(r.name)
+  }
 
   /** qualifier.termName */
   case class Select(qualifier: Tree, name: TermName) extends Tree

--- a/shared/src/main/scala/tastyquery/ast/Trees.scala
+++ b/shared/src/main/scala/tastyquery/ast/Trees.scala
@@ -73,6 +73,9 @@ object Trees {
   /** name */
   case class Ident(name: TermName) extends Tree
 
+  /** reference to a package, seen as a term */
+  class ReferencedPackage(override val name: TermName) extends Ident(name)
+
   /** qualifier.termName */
   case class Select(qualifier: Tree, name: TermName) extends Tree
 
@@ -189,7 +192,4 @@ object Trees {
   case object EmptyTree extends Tree
 
   val EmptyValDef: ValDef = ValDef(Names.Wildcard, EmptyTypeTree, EmptyTree)
-
-  // A marker for Trees or components which are not yet constructed correctly
-  case class DummyTree[T <: Object](components: T, todo: String) extends Tree
 }

--- a/shared/src/main/scala/tastyquery/ast/Types.scala
+++ b/shared/src/main/scala/tastyquery/ast/Types.scala
@@ -121,7 +121,13 @@ object Types {
     def resolveToSymbol: Symbol = ???
   }
 
-  class PackageRef(packageName: Name) extends TermRef(NoPrefix, packageName)
+  class PackageRef(val packageName: Name) extends TermRef(NoPrefix, packageName) {
+    override def toString: String = s"PackageRef($packageName)"
+  }
+
+  object PackageRef {
+    def unapply(r: PackageRef): Option[Name] = Some(r.packageName)
+  }
 
   case class TypeRef(override val prefix: Type, private var myDesignator: Designator) extends NamedType {
 

--- a/shared/src/main/scala/tastyquery/ast/Types.scala
+++ b/shared/src/main/scala/tastyquery/ast/Types.scala
@@ -117,7 +117,11 @@ object Types {
     def implicitName: TermName = name
 
     def underlyingRef: TermRef = this
+
+    def resolveToSymbol: Symbol = ???
   }
+
+  class PackageRef(packageName: Name) extends TermRef(NoPrefix, packageName)
 
   case class TypeRef(override val prefix: Type, private var myDesignator: Designator) extends NamedType {
 
@@ -186,9 +190,6 @@ object Types {
   case class RefinedType(parent: Type, refinedName: Name, refinedInfo: TypeBounds) extends TypeProxy with ValueType {
     override def underlying: Type = parent
   }
-
-  // A marker for Types or components which are not yet constructed correctly
-  case object DummyType extends Type
 
   trait TypeBounds(low: Type, high: Type)
 

--- a/shared/src/main/scala/tastyquery/reader/TreeUnpickler.scala
+++ b/shared/src/main/scala/tastyquery/reader/TreeUnpickler.scala
@@ -166,7 +166,7 @@ class TreeUnpickler(protected val reader: TastyReader, nameAtRef: NameTable) {
       val pid = readPotentiallyShared({
         assert(reader.readByte() == TERMREFpkg, reader.currentAddr)
         // Symbol is already created during symbol creation phase
-        ctx.createPackageSymbolIfNew(readName)
+        ctx.getPackageSymbol(readName).get
       })
       PackageDef(pid, reader.until(packageEnd)(readTopLevelStat (using ctx.withOwner(pid))))
     case _ => readStat

--- a/shared/src/main/scala/tastyquery/reader/TreeUnpickler.scala
+++ b/shared/src/main/scala/tastyquery/reader/TreeUnpickler.scala
@@ -3,7 +3,7 @@ package tastyquery.reader
 import tastyquery.Contexts._
 import tastyquery.ast.Constants.Constant
 import tastyquery.ast.Names._
-import tastyquery.ast.Symbols.{DummySymbol, Symbol}
+import tastyquery.ast.Symbols.Symbol
 import tastyquery.ast.Trees._
 import tastyquery.ast.TypeTrees._
 import tastyquery.ast.Types._
@@ -507,7 +507,10 @@ class TreeUnpickler(protected val reader: TastyReader, nameAtRef: NameTable) {
       // TODO: this might be more complicated than Ident
       Ident(name)
     case TERMREFpkg =>
-      DummyTree(readType, "TermRef into tree")
+      reader.readByte()
+      val name = readName
+      // TODO: create a termref and store as a tpe
+      ReferencedPackage(name)
     case TERMREFdirect =>
       reader.readByte()
       val sym = readSymRef
@@ -606,7 +609,7 @@ class TreeUnpickler(protected val reader: TastyReader, nameAtRef: NameTable) {
     case TERMREFpkg =>
       reader.readByte()
       val name = readName
-      TermRef(DummyType, name)
+      PackageRef(name)
     case TERMREF =>
       reader.readByte()
       val name = readName

--- a/test-sources/src/main/scala/simple_trees/nested/InQualifiedNestedPackage.scala
+++ b/test-sources/src/main/scala/simple_trees/nested/InQualifiedNestedPackage.scala
@@ -1,0 +1,3 @@
+package simple_trees.nested
+
+class InQualifiedNestedPackage


### PR DESCRIPTION
This PR introduces symbol organization.

1. Unpickling the AST section of a TASTy file now consists of two stages:
     a. Symbol creation
     b. Term creation.
   Because all symbols are created before all terms, forward references are easy to handle.
2. Symbols are organized in a tree: each symbol knows its owner and is added to the declarations of the owner. The root of the tree is the <root> package.