### PR TITLE
Refine symbol declaration hierarchy and store symbols in the corresponding trees

### DIFF
--- a/jvm/src/test/scala/BaseUnpicklingSuite.scala
+++ b/jvm/src/test/scala/BaseUnpicklingSuite.scala
@@ -1,0 +1,21 @@
+import tastyquery.Contexts
+import tastyquery.Contexts.Context
+import tastyquery.ast.Trees.Tree
+import tastyquery.ast.Types.Type
+import tastyquery.reader.TastyUnpickler
+
+import java.nio.file.{Files, Paths}
+
+abstract class BaseUnpicklingSuite extends munit.FunSuite {
+  val ResourceProperty = "test-resources"
+
+  def unpickle(filename: String)(using ctx: Context = Contexts.empty): Tree = {
+    val resourcePath = getResourcePath(filename)
+    val bytes        = Files.readAllBytes(Paths.get(resourcePath))
+    val unpickler    = new TastyUnpickler(bytes)
+    unpickler.unpickle(new TastyUnpickler.TreeSectionUnpickler()).get.unpickle (using ctx).head
+  }
+
+  def getResourcePath(name: String): String =
+    s"${System.getProperty(ResourceProperty)}/$name.tasty"
+}

--- a/jvm/src/test/scala/ReadTreeSuite.scala
+++ b/jvm/src/test/scala/ReadTreeSuite.scala
@@ -10,20 +10,9 @@ import dotty.tools.tasty.TastyFormat.NameTags
 
 import java.nio.file.{Files, Paths}
 
-class ReadTreeSuite extends munit.FunSuite {
+class ReadTreeSuite extends BaseUnpicklingSuite {
   type StructureCheck     = PartialFunction[Tree, Unit]
   type TypeStructureCheck = PartialFunction[Type, Unit]
-  val ResourceProperty = "test-resources"
-
-  def unpickle(filename: String): Tree = {
-    val resourcePath = getResourcePath(filename)
-    val bytes        = Files.readAllBytes(Paths.get(resourcePath))
-    val unpickler    = new TastyUnpickler(bytes)
-    unpickler.unpickle(new TastyUnpickler.TreeSectionUnpickler()).get.unpickle (using Contexts.empty).head
-  }
-
-  def getResourcePath(name: String): String =
-    s"${System.getProperty(ResourceProperty)}/$name.tasty"
 
   def containsSubtree(p: StructureCheck)(t: Tree): Boolean = {
     def rec(t: Tree): Boolean = containsSubtree(p)(t)

--- a/jvm/src/test/scala/SymbolSuite.scala
+++ b/jvm/src/test/scala/SymbolSuite.scala
@@ -1,10 +1,76 @@
 import tastyquery.Contexts
 import tastyquery.Contexts.Context
+import tastyquery.ast.Names.{EmptyPackageName, Name, SimpleName, TypeName}
+import tastyquery.ast.Symbols.{DeclaringSymbol, PackageClassSymbol, Symbol}
 
 class SymbolSuite extends BaseUnpicklingSuite {
+  type DeclarationPath = List[Name]
+
+  extension (path: DeclarationPath)
+    def toDebugString: String = path.map(_.toDebugString).mkString(".")
+
   def getUnpicklingContext(filename: String): Context = {
     val ctx = Contexts.empty
     unpickle(filename) (using ctx)
     ctx
+  }
+
+  private def followPath(root: Symbol, path: DeclarationPath): Symbol = path match {
+    case Nil => root
+    case next :: rest =>
+      assert(
+        clue(root).isInstanceOf[DeclaringSymbol],
+        s"Unexpected non-declaring symbol ${root.toDebugString} on the declaration path ${path.toDebugString}"
+      )
+      val nextDecl = root.asInstanceOf[DeclaringSymbol].getDecl(next)
+      assert(nextDecl.nonEmpty, s"No declaration for ${next.toDebugString} in ${root.toDebugString}")
+      val res = followPath(nextDecl.get, rest)
+      res
+  }
+
+  def assertContainsDeclaration(ctx: Context, path: DeclarationPath): Unit =
+    followPath(ctx.defn.RootPackage, path)
+
+  def getDeclsByPrefix(ctx: Context, prefix: DeclarationPath): List[Symbol] = {
+    def symbolsInSubtree(root: Symbol): List[Symbol] =
+      if (root.isInstanceOf[DeclaringSymbol]) {
+        root :: root.asInstanceOf[DeclaringSymbol].declarations.flatMap(symbolsInSubtree(_))
+      } else {
+        root :: Nil
+      }
+    symbolsInSubtree(followPath(ctx.defn.RootPackage, prefix))
+  }
+
+  def assertForallWithPrefix(ctx: Context, prefix: DeclarationPath, condition: Symbol => Boolean): Unit =
+    getDeclsByPrefix(ctx, prefix).forall(condition)
+
+  def assertContainsOnly(ctx: Context, prefix: DeclarationPath, symbolNames: Set[Name]): Unit =
+    assertForallWithPrefix(ctx, prefix, s => symbolNames.contains(s.name))
+
+  test("basic-symbol-structure") {
+    val ctx = getUnpicklingContext("empty_class/EmptyClass")
+    assertContainsDeclaration(ctx, SimpleName("empty_class") :: TypeName(SimpleName("EmptyClass")) :: Nil)
+    // EmptyClass and its constructor are the only declarations in empty_class package
+    assertContainsOnly(
+      ctx,
+      SimpleName("empty_class") :: Nil,
+      Set(SimpleName("empty_class"), TypeName(SimpleName("EmptyClass")), SimpleName("<init>"))
+    )
+
+  }
+
+  test("inner-class") {
+    val ctx = getUnpicklingContext("simple_trees/InnerClass")
+    // Inner is a declaration in InnerClass
+    assertContainsDeclaration(
+      ctx,
+      SimpleName("simple_trees") :: TypeName(SimpleName("InnerClass")) :: TypeName(SimpleName("Inner")) :: Nil
+    )
+  }
+
+  test("empty-package-contains-no-packages") {
+    val ctx = getUnpicklingContext("simple_trees/SharedPackageReference$package")
+    // simple_trees is not a subpackage of empty package
+    assertForallWithPrefix(ctx, EmptyPackageName :: Nil, s => !s.isInstanceOf[PackageClassSymbol])
   }
 }

--- a/jvm/src/test/scala/SymbolSuite.scala
+++ b/jvm/src/test/scala/SymbolSuite.scala
@@ -34,12 +34,12 @@ class SymbolSuite extends BaseUnpicklingSuite {
   def assertContainsDeclaration(ctx: Context, path: DeclarationPath): Unit =
     followPath(ctx.defn.RootPackage, path)
 
-  def getDeclsByPrefix(ctx: Context, prefix: DeclarationPath): List[Symbol] = {
-    def symbolsInSubtree(root: Symbol): List[Symbol] =
+  def getDeclsByPrefix(ctx: Context, prefix: DeclarationPath): Seq[Symbol] = {
+    def symbolsInSubtree(root: Symbol): Seq[Symbol] =
       if (root.isInstanceOf[DeclaringSymbol]) {
-        root :: root.asInstanceOf[DeclaringSymbol].declarations.flatMap(symbolsInSubtree(_))
+        root +: root.asInstanceOf[DeclaringSymbol].declarations.toSeq.flatMap(symbolsInSubtree(_))
       } else {
-        root :: Nil
+        Seq(root)
       }
     symbolsInSubtree(followPath(ctx.defn.RootPackage, prefix))
   }

--- a/jvm/src/test/scala/SymbolSuite.scala
+++ b/jvm/src/test/scala/SymbolSuite.scala
@@ -1,0 +1,10 @@
+import tastyquery.Contexts
+import tastyquery.Contexts.Context
+
+class SymbolSuite extends BaseUnpicklingSuite {
+  def getUnpicklingContext(filename: String): Context = {
+    val ctx = Contexts.empty
+    unpickle(filename) (using ctx)
+    ctx
+  }
+}

--- a/jvm/src/test/scala/SymbolSuite.scala
+++ b/jvm/src/test/scala/SymbolSuite.scala
@@ -93,5 +93,50 @@ class SymbolSuite extends BaseUnpicklingSuite {
       s => s.name == EmptyPackageName || !s.isInstanceOf[PackageClassSymbol]
     )
   }
+
+  test("class-parameter-is-a-decl") {
+    val ctx = getUnpicklingContext("simple_trees/ConstructorWithParameters")
+    assertContainsExactly(
+      ctx,
+      SimpleName("simple_trees") :: TypeName(SimpleName("ConstructorWithParameters")) :: Nil,
+      Set(
+        TypeName(SimpleName("ConstructorWithParameters")),
+        SimpleName("<init>"),
+        SimpleName("local"),
+        SimpleName("theVal"),
+        SimpleName("privateVal"),
+        // var and the setter for it
+        SimpleName("theVar"),
+        SimpleName("theVar_=")
+      )
+    )
+  }
+
+  test("class-type-parameter-is-not-a-decl") {
+    val ctx = getUnpicklingContext("simple_trees/GenericClass")
+    assertContainsExactly(
+      ctx,
+      SimpleName("simple_trees") :: Nil,
+      Set(SimpleName("simple_trees"), TypeName(SimpleName("GenericClass")), SimpleName("<init>"))
+    )
+  }
+
+  test("method-parameter-is-not-a-decl") {
+    val ctx = getUnpicklingContext("simple_trees/GenericMethod")
+    assertContainsExactly(
+      ctx,
+      SimpleName("simple_trees") :: TypeName(SimpleName("GenericMethod")) :: SimpleName("usesTypeParam") :: Nil,
+      Set(SimpleName("usesTypeParam"))
+    )
+  }
+
+  test("nested-method-is-not-a-decl") {
+    val ctx = getUnpicklingContext("simple_trees/NestedMethod")
+    assertContainsExactly(
+      ctx,
+      SimpleName("simple_trees") :: TypeName(SimpleName("NestedMethod")) :: SimpleName("outerMethod") :: Nil,
+      // innerMethod is not a declaration of outerMethod
+      Set(SimpleName("outerMethod"))
+    )
   }
 }

--- a/shared/src/main/scala/tastyquery/Contexts.scala
+++ b/shared/src/main/scala/tastyquery/Contexts.scala
@@ -78,6 +78,9 @@ object Contexts {
 
     def getPackageSymbol(name: TermName): PackageClassSymbol = defn.RootPackage.findPackageSymbol(name).get
 
-    def getSymbol(addr: Addr): Symbol = localSymbols(addr)
+    def getSymbol(addr: Addr): Symbol =
+      localSymbols(addr)
+    def getSymbol[T <: Symbol](addr: Addr, symbolFactory: SymbolFactory[T]): T =
+      symbolFactory.castSymbol(localSymbols(addr))
   }
 }

--- a/shared/src/main/scala/tastyquery/Contexts.scala
+++ b/shared/src/main/scala/tastyquery/Contexts.scala
@@ -43,35 +43,21 @@ object Contexts {
       owner.addDecl(sym)
     }
 
-    def createSymbolIfNew(addr: Addr, name: Name): Symbol = {
+    def createSymbolIfNew[T <: Symbol](addr: Addr, name: Name, factory: SymbolFactory[T]): T = {
       if (!hasSymbolAt(addr)) {
-        registerSym(addr, new Symbol(name, owner))
+        registerSym(addr, factory.createSymbol(name, owner))
       }
-      localSymbols(addr)
-    }
-
-    def createClassSymbolIfNew(addr: Addr, name: Name): ClassSymbol = {
-      if (!hasSymbolAt(addr)) {
-        registerSym(addr, new ClassSymbol(name, owner))
-      }
-      localSymbols(addr).asInstanceOf[ClassSymbol]
-    }
-
-    def createMethodSymbolIfNew(addr: Addr, name: TermName): MethodSymbol = {
-      if (!hasSymbolAt(addr)) {
-        registerSym(addr, new MethodSymbol(name, owner))
-      }
-      localSymbols(addr).asInstanceOf[MethodSymbol]
+      localSymbols(addr).asInstanceOf[T]
     }
 
     def createPackageSymbolIfNew(name: TermName): PackageClassSymbol = {
       def create(): PackageClassSymbol = {
         val trueOwner = if (owner == defn.EmptyPackage) defn.RootPackage else owner
-        val sym       = new PackageClassSymbol(name, trueOwner)
+        val sym       = PackageClassSymbolFactory.createSymbol(name, trueOwner)
         sym
       }
 
-      getPackageSymbol(name) match {
+      defn.RootPackage.findPackageSymbol(name) match {
         case Some(pkg) => pkg
         case None =>
           name match {
@@ -90,7 +76,7 @@ object Contexts {
       }
     }
 
-    def getPackageSymbol(name: TermName): Option[PackageClassSymbol] = defn.RootPackage.findPackageSymbol(name)
+    def getPackageSymbol(name: TermName): PackageClassSymbol = defn.RootPackage.findPackageSymbol(name).get
 
     def getSymbol(addr: Addr): Symbol = localSymbols(addr)
   }

--- a/shared/src/main/scala/tastyquery/Contexts.scala
+++ b/shared/src/main/scala/tastyquery/Contexts.scala
@@ -20,9 +20,9 @@ object Contexts {
   }
 
   class Context private[Contexts] (
-    val owner: DeclaringSymbol,
+    val owner: Symbol,
     val defn: Definitions,
-    val localSymbols: HashMap[Addr, Symbol] = new mutable.HashMap[Addr, Symbol]()
+    val localSymbols: mutable.HashMap[Addr, Symbol] = new mutable.HashMap[Addr, Symbol]()
   ) {
     var enclosingLambdas: Map[Addr, TypeLambda] = Map.empty
 
@@ -32,20 +32,34 @@ object Contexts {
       copy
     }
 
-    def withOwner(newOwner: DeclaringSymbol): Context =
+    def withOwner(newOwner: Symbol): Context =
       if (newOwner == owner) this
       else new Context(newOwner, defn, localSymbols)
 
     def hasSymbolAt(addr: Addr): Boolean = localSymbols.contains(addr)
 
-    def registerSym(addr: Addr, sym: Symbol): Unit = {
+    private def registerSym(addr: Addr, sym: Symbol, addToDecls: Boolean): Unit = {
       localSymbols(addr) = sym
-      owner.addDecl(sym)
+      if (addToDecls && owner.isInstanceOf[DeclaringSymbol])
+        owner.asInstanceOf[DeclaringSymbol].addDecl(sym)
     }
 
-    def createSymbolIfNew[T <: Symbol](addr: Addr, name: Name, factory: SymbolFactory[T]): T = {
+    /**
+     * Creates a new symbol at @addr with @name. The symbol is added to the owner's declarations if both
+     * 1) @addToDecls is true.
+     *    Example: true for valdef and defdef, false for parameters and type parameters
+     * 2) the owner is a declaring symbol.
+     *    Example: a method is added to the declarations of its class, but a nested method is not added
+     *    to declarations of its owner method.
+     */
+    def createSymbolIfNew[T <: Symbol](
+      addr: Addr,
+      name: Name,
+      factory: SymbolFactory[T],
+      addToDecls: Boolean = false
+    ): T = {
       if (!hasSymbolAt(addr)) {
-        registerSym(addr, factory.createSymbol(name, owner))
+        registerSym(addr, factory.createSymbol(name, owner), addToDecls)
       }
       localSymbols(addr).asInstanceOf[T]
     }

--- a/shared/src/main/scala/tastyquery/ast/Names.scala
+++ b/shared/src/main/scala/tastyquery/ast/Names.scala
@@ -78,6 +78,7 @@ object Names {
 
     def isEmpty: Boolean
 
+    def toDebugString: String = toString
   }
 
   abstract class TermName extends Name {
@@ -174,5 +175,7 @@ object Names {
     override def isEmpty: Boolean = toTermName.isEmpty
 
     override def toString: String = toTermName.toString
+
+    override def toDebugString: String = s"${toString}/T"
   }
 }

--- a/shared/src/main/scala/tastyquery/ast/Names.scala
+++ b/shared/src/main/scala/tastyquery/ast/Names.scala
@@ -78,7 +78,6 @@ object Names {
 
     def isEmpty: Boolean
 
-    override def hashCode: Int = System.identityHashCode(this)
   }
 
   abstract class TermName extends Name {
@@ -102,8 +101,6 @@ object Names {
     override def asSimpleName: SimpleName = this
 
     override def isEmpty: Boolean = name.length == 0
-
-    override def hashCode: Int = name.hashCode
 
     override def toString: String = name
   }

--- a/shared/src/main/scala/tastyquery/ast/Symbols.scala
+++ b/shared/src/main/scala/tastyquery/ast/Symbols.scala
@@ -10,6 +10,7 @@ object Symbols {
 
   abstract class Symbol private[Symbols] (val name: Name, val owner: Symbol) {
     override def toString: String = s"symbol[$name]"
+    def toDebugString             = toString
   }
 
   object Symbol {
@@ -21,10 +22,14 @@ object Symbols {
   abstract class DeclaringSymbol(override val name: Name, override val owner: Symbol) extends Symbol(name, owner) {
     /* A map from the name of a declaration directly inside this symbol to the corresponding symbol
      * The qualifiers on the name are not dropped. For instance, the package names are always fully qualified. */
-    protected val declarations: mutable.HashMap[Name, Symbol] = mutable.HashMap[Name, Symbol]()
+    protected val myDeclarations: mutable.HashMap[Name, Symbol] = mutable.HashMap[Name, Symbol]()
 
-    def addDecl(decl: Symbol): Unit         = declarations(decl.name) = decl
-    def getDecl(name: Name): Option[Symbol] = declarations.get(name)
+    def addDecl(decl: Symbol): Unit         = myDeclarations(decl.name) = decl
+    def getDecl(name: Name): Option[Symbol] = myDeclarations.get(name)
+    def declarations: List[Symbol] = myDeclarations.values.toList
+
+    override def toDebugString: String =
+      s"${super.toString} with declarations [${myDeclarations.keys.map(_.toDebugString).mkString(", ")}]"
   }
 
   class ClassSymbol(override val name: Name, override val owner: Symbol) extends DeclaringSymbol(name, owner)

--- a/shared/src/main/scala/tastyquery/ast/Symbols.scala
+++ b/shared/src/main/scala/tastyquery/ast/Symbols.scala
@@ -8,7 +8,7 @@ import dotty.tools.tasty.TastyFormat.NameTags
 object Symbols {
   val NoSymbol = new Symbol(Names.EmptyTermName, null)
 
-  class Symbol(val name: Name, val owner: DeclaringSymbol) {
+  class Symbol private[Symbols] (val name: Name, val owner: DeclaringSymbol) {
     override def toString: String = s"symbol[$name]"
   }
 
@@ -33,8 +33,7 @@ object Symbols {
     def getDecl(name: Name): Option[Symbol] = declarations.get(name)
   }
 
-  class MethodSymbol(override val name: TermName, override val owner: DeclaringSymbol)
-      extends DeclaringSymbol(name, owner)
+  class MethodSymbol(override val name: Name, override val owner: DeclaringSymbol) extends DeclaringSymbol(name, owner)
 
   class ClassSymbol(override val name: Name, override val owner: DeclaringSymbol) extends DeclaringSymbol(name, owner)
 
@@ -54,5 +53,26 @@ object Symbols {
 
     private def getPackageDecl(packageName: TermName): Option[PackageClassSymbol] =
       getDecl(packageName).map(_.asInstanceOf[PackageClassSymbol])
+  }
+
+  abstract class SymbolFactory[T <: Symbol] {
+    def createSymbol(name: Name, owner: DeclaringSymbol): T
+  }
+
+  object RegularSymbolFactory extends SymbolFactory[Symbol] {
+    override def createSymbol(name: Name, owner: DeclaringSymbol): Symbol = new Symbol(name, owner)
+  }
+
+  object ClassSymbolFactory extends SymbolFactory[ClassSymbol] {
+    override def createSymbol(name: Name, owner: DeclaringSymbol): ClassSymbol = new ClassSymbol(name, owner)
+  }
+
+  object PackageClassSymbolFactory extends SymbolFactory[PackageClassSymbol] {
+    override def createSymbol(name: Name, owner: DeclaringSymbol): PackageClassSymbol =
+      new PackageClassSymbol(name, owner)
+  }
+
+  object MethodSymbolFactory extends SymbolFactory[MethodSymbol] {
+    override def createSymbol(name: Name, owner: DeclaringSymbol): MethodSymbol = new MethodSymbol(name, owner)
   }
 }

--- a/shared/src/main/scala/tastyquery/ast/Symbols.scala
+++ b/shared/src/main/scala/tastyquery/ast/Symbols.scala
@@ -6,15 +6,17 @@ import tastyquery.ast.Names._
 import dotty.tools.tasty.TastyFormat.NameTags
 
 object Symbols {
-  val NoSymbol = new Symbol(Names.EmptyTermName, null)
+  val NoSymbol = new RegularSymbol(Names.EmptyTermName, null)
 
-  class Symbol private[Symbols] (val name: Name, val owner: DeclaringSymbol) {
+  abstract class Symbol private[Symbols] (val name: Name, val owner: Symbol) {
     override def toString: String = s"symbol[$name]"
   }
 
   object Symbol {
     def unapply(s: Symbol): Option[Name] = Some(s.name)
   }
+
+  final class RegularSymbol(override val name: Name, override val owner: Symbol) extends Symbol(name, owner)
 
   abstract class DeclaringSymbol(override val name: Name, override val owner: DeclaringSymbol)
       extends Symbol(name, owner) {
@@ -59,8 +61,8 @@ object Symbols {
     def createSymbol(name: Name, owner: DeclaringSymbol): T
   }
 
-  object RegularSymbolFactory extends SymbolFactory[Symbol] {
-    override def createSymbol(name: Name, owner: DeclaringSymbol): Symbol = new Symbol(name, owner)
+  object RegularSymbolFactory extends SymbolFactory[RegularSymbol] {
+    override def createSymbol(name: Name, owner: DeclaringSymbol): RegularSymbol = new RegularSymbol(name, owner)
   }
 
   object ClassSymbolFactory extends SymbolFactory[ClassSymbol] {

--- a/shared/src/main/scala/tastyquery/ast/Symbols.scala
+++ b/shared/src/main/scala/tastyquery/ast/Symbols.scala
@@ -59,22 +59,31 @@ object Symbols {
 
   abstract class SymbolFactory[T <: Symbol] {
     def createSymbol(name: Name, owner: DeclaringSymbol): T
+    def castSymbol(symbol: Symbol): T
   }
 
   object RegularSymbolFactory extends SymbolFactory[RegularSymbol] {
     override def createSymbol(name: Name, owner: DeclaringSymbol): RegularSymbol = new RegularSymbol(name, owner)
+
+    override def castSymbol(symbol: Symbol): RegularSymbol = symbol.asInstanceOf[RegularSymbol]
   }
 
   object ClassSymbolFactory extends SymbolFactory[ClassSymbol] {
     override def createSymbol(name: Name, owner: DeclaringSymbol): ClassSymbol = new ClassSymbol(name, owner)
+
+    override def castSymbol(symbol: Symbol): ClassSymbol = symbol.asInstanceOf[ClassSymbol]
   }
 
   object PackageClassSymbolFactory extends SymbolFactory[PackageClassSymbol] {
     override def createSymbol(name: Name, owner: DeclaringSymbol): PackageClassSymbol =
       new PackageClassSymbol(name, owner)
+
+    override def castSymbol(symbol: Symbol): PackageClassSymbol = symbol.asInstanceOf[PackageClassSymbol]
   }
 
   object MethodSymbolFactory extends SymbolFactory[MethodSymbol] {
     override def createSymbol(name: Name, owner: DeclaringSymbol): MethodSymbol = new MethodSymbol(name, owner)
+
+    override def castSymbol(symbol: Symbol): MethodSymbol = symbol.asInstanceOf[MethodSymbol]
   }
 }

--- a/shared/src/main/scala/tastyquery/ast/Symbols.scala
+++ b/shared/src/main/scala/tastyquery/ast/Symbols.scala
@@ -18,15 +18,7 @@ object Symbols {
 
   final class RegularSymbol(override val name: Name, override val owner: Symbol) extends Symbol(name, owner)
 
-  abstract class DeclaringSymbol(override val name: Name, override val owner: DeclaringSymbol)
-      extends Symbol(name, owner) {
-    if (owner != null) {
-      // Declaring symbol is always a declaration in its owner
-      owner.addDecl(this)
-    } else {
-      // Root package is the only symbol that is allowed to not have an owner
-      assert(name == RootName)
-    }
+  abstract class DeclaringSymbol(override val name: Name, override val owner: Symbol) extends Symbol(name, owner) {
     /* A map from the name of a declaration directly inside this symbol to the corresponding symbol
      * The qualifiers on the name are not dropped. For instance, the package names are always fully qualified. */
     protected val declarations: mutable.HashMap[Name, Symbol] = mutable.HashMap[Name, Symbol]()
@@ -35,13 +27,18 @@ object Symbols {
     def getDecl(name: Name): Option[Symbol] = declarations.get(name)
   }
 
-  class MethodSymbol(override val name: Name, override val owner: DeclaringSymbol) extends DeclaringSymbol(name, owner)
-
-  class ClassSymbol(override val name: Name, override val owner: DeclaringSymbol) extends DeclaringSymbol(name, owner)
+  class ClassSymbol(override val name: Name, override val owner: Symbol) extends DeclaringSymbol(name, owner)
 
   // TODO: typename or term name?
-  class PackageClassSymbol(override val name: Name, override val owner: DeclaringSymbol)
+  class PackageClassSymbol(override val name: Name, override val owner: PackageClassSymbol)
       extends ClassSymbol(name, owner) {
+    if (owner != null) {
+      // A package symbol is always a declaration in its owner package
+      owner.addDecl(this)
+    } else {
+      // Root package is the only symbol that is allowed to not have an owner
+      assert(name == RootName)
+    }
     def findPackageSymbol(packageName: TermName): Option[PackageClassSymbol] = packageName match {
       case _: SimpleName => getPackageDecl(packageName)
       case QualifiedName(NameTags.QUALIFIED, prefix, suffix) =>
@@ -58,32 +55,26 @@ object Symbols {
   }
 
   abstract class SymbolFactory[T <: Symbol] {
-    def createSymbol(name: Name, owner: DeclaringSymbol): T
+    def createSymbol(name: Name, owner: Symbol): T
     def castSymbol(symbol: Symbol): T
   }
 
   object RegularSymbolFactory extends SymbolFactory[RegularSymbol] {
-    override def createSymbol(name: Name, owner: DeclaringSymbol): RegularSymbol = new RegularSymbol(name, owner)
+    override def createSymbol(name: Name, owner: Symbol): RegularSymbol = new RegularSymbol(name, owner)
 
     override def castSymbol(symbol: Symbol): RegularSymbol = symbol.asInstanceOf[RegularSymbol]
   }
 
   object ClassSymbolFactory extends SymbolFactory[ClassSymbol] {
-    override def createSymbol(name: Name, owner: DeclaringSymbol): ClassSymbol = new ClassSymbol(name, owner)
+    override def createSymbol(name: Name, owner: Symbol): ClassSymbol = new ClassSymbol(name, owner)
 
     override def castSymbol(symbol: Symbol): ClassSymbol = symbol.asInstanceOf[ClassSymbol]
   }
 
   object PackageClassSymbolFactory extends SymbolFactory[PackageClassSymbol] {
-    override def createSymbol(name: Name, owner: DeclaringSymbol): PackageClassSymbol =
-      new PackageClassSymbol(name, owner)
+    override def createSymbol(name: Name, owner: Symbol): PackageClassSymbol =
+      new PackageClassSymbol(name, owner.asInstanceOf[PackageClassSymbol])
 
     override def castSymbol(symbol: Symbol): PackageClassSymbol = symbol.asInstanceOf[PackageClassSymbol]
-  }
-
-  object MethodSymbolFactory extends SymbolFactory[MethodSymbol] {
-    override def createSymbol(name: Name, owner: DeclaringSymbol): MethodSymbol = new MethodSymbol(name, owner)
-
-    override def castSymbol(symbol: Symbol): MethodSymbol = symbol.asInstanceOf[MethodSymbol]
   }
 }

--- a/shared/src/main/scala/tastyquery/ast/Trees.scala
+++ b/shared/src/main/scala/tastyquery/ast/Trees.scala
@@ -4,7 +4,7 @@ import tastyquery.ast.Constants.Constant
 import tastyquery.ast.Names.{Name, TermName, TypeName}
 import tastyquery.ast.Types.{Type, TypeBounds}
 import tastyquery.ast.TypeTrees.*
-import tastyquery.ast.Symbols.{NoSymbol, PackageClassSymbol, Symbol, MethodSymbol, ClassSymbol}
+import tastyquery.ast.Symbols.{ClassSymbol, MethodSymbol, NoSymbol, PackageClassSymbol, RegularSymbol, Symbol}
 
 object Trees {
 
@@ -49,14 +49,14 @@ object Trees {
   case class Class(name: TypeName, rhs: Template, override val symbol: ClassSymbol) extends TypeDef(name, symbol)
 
   /** A type member has a type tree rhs if the member is defined by the user, or typebounds if it's synthetic */
-  case class TypeMember(name: TypeName, rhs: TypeTree | TypeBounds, override val symbol: Symbol)
+  case class TypeMember(name: TypeName, rhs: TypeTree | TypeBounds, override val symbol: RegularSymbol)
       extends TypeDef(name, symbol)
 
   /** The bounds are a type tree if the method is defined by the user and bounds-only if it's synthetic */
   case class TypeParam(
     name: TypeName,
     bounds: TypeBoundsTree | TypeBounds | TypeLambdaTree,
-    override val symbol: Symbol
+    override val symbol: RegularSymbol
   ) extends TypeDef(name, symbol)
 
   /**
@@ -70,7 +70,7 @@ object Trees {
       extends Tree
 
   /** mods val name: tpt = rhs */
-  case class ValDef(name: TermName, tpt: TypeTree, rhs: Tree, override val symbol: Symbol)
+  case class ValDef(name: TermName, tpt: TypeTree, rhs: Tree, override val symbol: RegularSymbol)
       extends Tree
       with DefTree(symbol)
 
@@ -156,7 +156,7 @@ object Trees {
   case class CaseDef(pattern: Tree, guard: Tree, body: Tree) extends Tree
 
   /** pattern in {@link Unapply} */
-  case class Bind(name: Name, body: Tree, override val symbol: Symbol) extends Tree with DefTree(symbol)
+  case class Bind(name: Name, body: Tree, override val symbol: RegularSymbol) extends Tree with DefTree(symbol)
 
   /** tree_1 | ... | tree_n */
   case class Alternative(trees: List[Tree]) extends Tree

--- a/shared/src/main/scala/tastyquery/ast/Trees.scala
+++ b/shared/src/main/scala/tastyquery/ast/Trees.scala
@@ -3,14 +3,16 @@ package tastyquery.ast
 import tastyquery.ast.Constants.Constant
 import tastyquery.ast.Names.{Name, TermName, TypeName}
 import tastyquery.ast.Types.{Type, TypeBounds}
-import tastyquery.ast.TypeTrees._
-import tastyquery.ast.Symbols.Symbol
+import tastyquery.ast.TypeTrees.*
+import tastyquery.ast.Symbols.{NoSymbol, PackageClassSymbol, Symbol, MethodSymbol, ClassSymbol}
 
 object Trees {
 
   abstract class Tree
 
-  case class PackageDef(pid: Symbol, stats: List[Tree]) extends Tree
+  trait DefTree(val symbol: Symbol)
+
+  case class PackageDef(pid: PackageClassSymbol, stats: List[Tree]) extends Tree with DefTree(pid)
 
   case class ImportSelector(imported: Ident, renamed: Tree = EmptyTree, bound: TypeTree = EmptyTypeTree) extends Tree {
 
@@ -42,15 +44,20 @@ object Trees {
    *  mods type name >: lo <: hi,          if rhs = TypeBoundsTree(lo, hi)      or
    *  mods type name >: lo <: hi = rhs     if rhs = TypeBoundsTree(lo, hi, alias) and opaque in mods
    */
-  abstract class TypeDef extends Tree
+  abstract class TypeDef(name: TypeName, override val symbol: Symbol) extends Tree with DefTree(symbol)
 
-  case class Class(name: TypeName, rhs: Template) extends TypeDef
+  case class Class(name: TypeName, rhs: Template, override val symbol: ClassSymbol) extends TypeDef(name, symbol)
 
   /** A type member has a type tree rhs if the member is defined by the user, or typebounds if it's synthetic */
-  case class TypeMember(name: TypeName, rhs: TypeTree | TypeBounds) extends TypeDef
+  case class TypeMember(name: TypeName, rhs: TypeTree | TypeBounds, override val symbol: Symbol)
+      extends TypeDef(name, symbol)
 
   /** The bounds are a type tree if the method is defined by the user and bounds-only if it's synthetic */
-  case class TypeParam(name: TypeName, bounds: TypeBoundsTree | TypeBounds | TypeLambdaTree) extends TypeDef
+  case class TypeParam(
+    name: TypeName,
+    bounds: TypeBoundsTree | TypeBounds | TypeLambdaTree,
+    override val symbol: Symbol
+  ) extends TypeDef(name, symbol)
 
   /**
    * extends parents { self => body }
@@ -63,12 +70,21 @@ object Trees {
       extends Tree
 
   /** mods val name: tpt = rhs */
-  case class ValDef(name: TermName, tpt: TypeTree, rhs: Tree) extends Tree
+  case class ValDef(name: TermName, tpt: TypeTree, rhs: Tree, override val symbol: Symbol)
+      extends Tree
+      with DefTree(symbol)
 
   type ParamsClause = List[ValDef] | List[TypeParam]
 
   /** mods def name[tparams](vparams_1)...(vparams_n): tpt = rhs */
-  case class DefDef(name: TermName, params: List[ParamsClause], tpt: TypeTree, rhs: Tree) extends Tree
+  case class DefDef(
+    name: TermName,
+    params: List[ParamsClause],
+    tpt: TypeTree,
+    rhs: Tree,
+    override val symbol: MethodSymbol
+  ) extends Tree
+      with DefTree(symbol)
 
   /** name */
   case class Ident(name: TermName) extends Tree
@@ -140,7 +156,7 @@ object Trees {
   case class CaseDef(pattern: Tree, guard: Tree, body: Tree) extends Tree
 
   /** pattern in {@link Unapply} */
-  case class Bind(name: Name, body: Tree) extends Tree
+  case class Bind(name: Name, body: Tree, override val symbol: Symbol) extends Tree with DefTree(symbol)
 
   /** tree_1 | ... | tree_n */
   case class Alternative(trees: List[Tree]) extends Tree
@@ -197,5 +213,5 @@ object Trees {
 
   case object EmptyTree extends Tree
 
-  val EmptyValDef: ValDef = ValDef(Names.Wildcard, EmptyTypeTree, EmptyTree)
+  val EmptyValDef: ValDef = ValDef(Names.Wildcard, EmptyTypeTree, EmptyTree, NoSymbol)
 }

--- a/shared/src/main/scala/tastyquery/ast/Trees.scala
+++ b/shared/src/main/scala/tastyquery/ast/Trees.scala
@@ -4,7 +4,7 @@ import tastyquery.ast.Constants.Constant
 import tastyquery.ast.Names.{Name, TermName, TypeName}
 import tastyquery.ast.Types.{Type, TypeBounds}
 import tastyquery.ast.TypeTrees.*
-import tastyquery.ast.Symbols.{ClassSymbol, MethodSymbol, NoSymbol, PackageClassSymbol, RegularSymbol, Symbol}
+import tastyquery.ast.Symbols.{ClassSymbol, NoSymbol, PackageClassSymbol, RegularSymbol, Symbol}
 
 object Trees {
 
@@ -82,7 +82,7 @@ object Trees {
     params: List[ParamsClause],
     tpt: TypeTree,
     rhs: Tree,
-    override val symbol: MethodSymbol
+    override val symbol: RegularSymbol
   ) extends Tree
       with DefTree(symbol)
 

--- a/shared/src/main/scala/tastyquery/ast/TypeTrees.scala
+++ b/shared/src/main/scala/tastyquery/ast/TypeTrees.scala
@@ -1,7 +1,7 @@
 package tastyquery.ast
 
 import tastyquery.ast.Names.{EmptyTermName, EmptyTypeName, TypeName}
-import tastyquery.ast.Symbols.Symbol
+import tastyquery.ast.Symbols.RegularSymbol
 import tastyquery.ast.Trees.{DefTree, Tree, TypeParam}
 import tastyquery.ast.Types.{Type, TypeBounds}
 
@@ -42,7 +42,7 @@ object TypeTrees {
 
   case class TypeCaseDef(pattern: TypeTree, body: TypeTree)
 
-  case class TypeTreeBind(name: TypeName, body: TypeTree, override val symbol: Symbol)
+  case class TypeTreeBind(name: TypeName, body: TypeTree, override val symbol: RegularSymbol)
       extends TypeTree
       with DefTree(symbol)
 

--- a/shared/src/main/scala/tastyquery/ast/TypeTrees.scala
+++ b/shared/src/main/scala/tastyquery/ast/TypeTrees.scala
@@ -1,7 +1,8 @@
 package tastyquery.ast
 
 import tastyquery.ast.Names.{EmptyTermName, EmptyTypeName, TypeName}
-import tastyquery.ast.Trees.{Tree, TypeParam}
+import tastyquery.ast.Symbols.Symbol
+import tastyquery.ast.Trees.{DefTree, Tree, TypeParam}
 import tastyquery.ast.Types.{Type, TypeBounds}
 
 object TypeTrees {
@@ -41,7 +42,9 @@ object TypeTrees {
 
   case class TypeCaseDef(pattern: TypeTree, body: TypeTree)
 
-  case class TypeTreeBind(name: TypeName, body: TypeTree) extends TypeTree
+  case class TypeTreeBind(name: TypeName, body: TypeTree, override val symbol: Symbol)
+      extends TypeTree
+      with DefTree(symbol)
 
   case object EmptyTypeTree extends TypeTree
 

--- a/shared/src/main/scala/tastyquery/reader/TreeUnpickler.scala
+++ b/shared/src/main/scala/tastyquery/reader/TreeUnpickler.scala
@@ -9,6 +9,7 @@ import tastyquery.ast.Symbols.{
   MethodSymbol,
   MethodSymbolFactory,
   NoSymbol,
+  RegularSymbol,
   RegularSymbolFactory,
   Symbol
 }
@@ -218,9 +219,9 @@ class TreeUnpickler(protected val reader: TastyReader, nameAtRef: NameTable) {
         Class(name, readTemplate (using ctx.withOwner(classSymbol)), classSymbol)
       } else {
         if (tagFollowShared == TYPEBOUNDS)
-          TypeMember(name, readTypeBounds, symbol)
+          TypeMember(name, readTypeBounds, symbol.asInstanceOf[RegularSymbol])
         else
-          TypeMember(name, readTypeTree, symbol)
+          TypeMember(name, readTypeTree, symbol.asInstanceOf[RegularSymbol])
       }
       // TODO: read modifiers
       skipModifiers(end)
@@ -294,7 +295,7 @@ class TreeUnpickler(protected val reader: TastyReader, nameAtRef: NameTable) {
       val name   = readName.toTypeName
       val bounds = readTypeParamType
       skipModifiers(end)
-      TypeParam(name, bounds, ctx.getSymbol(start))
+      TypeParam(name, bounds, ctx.getSymbol(start).asInstanceOf[RegularSymbol])
     }
     var acc = new ListBuffer[TypeParam]()
     while (reader.nextByte == TYPEPARAM) {
@@ -407,7 +408,7 @@ class TreeUnpickler(protected val reader: TastyReader, nameAtRef: NameTable) {
       else readTerm (using insideCtx)
     skipModifiers(end)
     tag match {
-      case VALDEF | PARAM => ValDef(name, tpt, rhs, ctx.getSymbol(start))
+      case VALDEF | PARAM => ValDef(name, tpt, rhs, ctx.getSymbol(start).asInstanceOf[RegularSymbol])
       case DEFDEF =>
         DefDef(name, params, tpt, rhs, ctx.getSymbol(start).asInstanceOf[MethodSymbol])
     }
@@ -522,7 +523,7 @@ class TreeUnpickler(protected val reader: TastyReader, nameAtRef: NameTable) {
       val typ  = readType
       val term = readTerm
       skipModifiers(end)
-      Bind(name, term, ctx.getSymbol(start))
+      Bind(name, term, ctx.getSymbol(start).asInstanceOf[RegularSymbol])
     case ALTERNATIVE =>
       reader.readByte()
       val end = reader.readEnd()
@@ -842,7 +843,7 @@ class TreeUnpickler(protected val reader: TastyReader, nameAtRef: NameTable) {
         TypeIdent(typeName)
       } else readTypeTree
       skipModifiers(end)
-      TypeTreeBind(name, body, ctx.getSymbol(start))
+      TypeTreeBind(name, body, ctx.getSymbol(start).asInstanceOf[RegularSymbol])
     // Type tree for a type member (abstract or bounded opaque)
     case TYPEBOUNDStpt => readBoundedTypeTree
     case BYNAMEtpt =>

--- a/shared/src/main/scala/tastyquery/reader/TreeUnpickler.scala
+++ b/shared/src/main/scala/tastyquery/reader/TreeUnpickler.scala
@@ -66,7 +66,7 @@ class TreeUnpickler(protected val reader: TastyReader, nameAtRef: NameTable) {
         val end  = reader.readEnd()
         val name = if (tag == TYPEPARAM) readName.toTypeName else readName
         val newSymbol =
-          ctx.createSymbolIfNew(start, name, RegularSymbolFactory, addToDecls = (tag == VALDEF || tag == DEFDEF))
+          ctx.createSymbolIfNew(start, name, RegularSymbolFactory, addToDecls = (tag != TYPEPARAM))
         reader.until(end)(createSymbols (using ctx.withOwner(newSymbol)))
       case BIND =>
         val end        = reader.readEnd()

--- a/test-sources/src/main/scala/simple_trees/NestedMethod.scala
+++ b/test-sources/src/main/scala/simple_trees/NestedMethod.scala
@@ -1,0 +1,7 @@
+package simple_trees
+
+class NestedMethod {
+  def outerMethod: Unit = {
+    def innerMethod: Unit = ()
+  }
+}


### PR DESCRIPTION
This PR trims down the symbol tree: now it consists only of declarations, i.e. symbols that can be selected. All symbols are now also stored in the corresponding trees.