### PR TITLE
Read TYPEREFin in a stub way

### DIFF
--- a/jvm/src/test/scala/ReadTreeSuite.scala
+++ b/jvm/src/test/scala/ReadTreeSuite.scala
@@ -1714,4 +1714,17 @@ class ReadTreeSuite extends BaseUnpicklingSuite {
 
     // TODO: once references are created, check correctness
   }
+
+  test("typerefin") {
+    val tree = unpickle("simple_trees/TypeRefIn")
+
+    val typerefCheck: StructureCheck = {
+      case TypeApply(
+            Select(qualifier, SignedName(SimpleName("withArray"), _, _)),
+            // TODO: check the namespace ("in") once its taken into account
+            TypeWrapper(TypeRef(TermRef(NoPrefix, Symbol(SimpleName("arr"))), TypeName(SimpleName("T")))) :: Nil
+          ) =>
+    }
+    assert(containsSubtree(typerefCheck)(clue(tree)))
+  }
 }

--- a/shared/src/main/scala/tastyquery/reader/TreeUnpickler.scala
+++ b/shared/src/main/scala/tastyquery/reader/TreeUnpickler.scala
@@ -650,6 +650,14 @@ class TreeUnpickler(protected val reader: TastyReader, nameAtRef: NameTable) {
       reader.readByte()
       val name = readName.toTypeName
       TypeRef(readType, name)
+    case TYPEREFin =>
+      reader.readByte()
+      reader.readEnd()
+      val name = readName.toTypeName
+      val prefix = readType
+      // TODO: use the namespace
+      val namespace = readType
+      TypeRef(prefix, name)
     case TYPEREFdirect =>
       reader.readByte()
       val sym = readSymRef

--- a/test-sources/src/main/scala/simple_trees/TypeRefIn.scala
+++ b/test-sources/src/main/scala/simple_trees/TypeRefIn.scala
@@ -1,0 +1,7 @@
+package simple_trees
+
+class TypeRefIn {
+  def withArray[U](arr: Array[U]): Unit = ()
+
+  def withArrayOfSubtype[T](arr: Array[_ <: T]) = withArray(arr)
+}


### PR DESCRIPTION
Ignore the namespace, similarly to other ...in tags.