### PR TITLE
Implement a TASTy project reader

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -14,7 +14,8 @@ lazy val tastyQuery =
     .settings(name := "tasty-query", version := "0.1-SNAPSHOT")
     .settings(
       libraryDependencies += "org.scala-lang" %% "tasty-core" % "3.0.0",
-      libraryDependencies += "org.scalameta"  %% "munit"      % "0.7.26" % Test,
+      libraryDependencies += "commons-io" % "commons-io" % "2.11.0",
+      libraryDependencies += "org.scalameta" %% "munit" % "0.7.26" % Test,
       testFrameworks += new TestFramework("munit.Framework")
     )
     .settings(javaOptions += {

--- a/jvm/src/main/scala/Main.scala
+++ b/jvm/src/main/scala/Main.scala
@@ -10,6 +10,8 @@ object Main {
     } else {
       val filename = args(0)
       val unpickler = new TastyUnpickler(Files.readAllBytes(Paths.get(filename)))
-      println(unpickler.unpickle(new TastyUnpickler.TreeSectionUnpickler()).get.unpickle(using Contexts.empty))
+      println(
+        unpickler.unpickle(new TastyUnpickler.TreeSectionUnpickler()).get.unpickle(using Contexts.empty(filename))
+      )
     }
 }

--- a/jvm/src/main/scala/Main.scala
+++ b/jvm/src/main/scala/Main.scala
@@ -1,17 +1,32 @@
 import java.nio.file.{Files, Paths}
-
 import tastyquery.reader.TastyUnpickler
 import tastyquery.Contexts
+import tastyquery.api.ProjectReader
+
+import java.net.URL
+import java.net.URLClassLoader
 
 object Main {
   def main(args: Array[String]): Unit =
-    if (args.isEmpty) {
-      println("Please enter a tasty file to read")
-    } else {
-      val filename = args(0)
-      val unpickler = new TastyUnpickler(Files.readAllBytes(Paths.get(filename)))
-      println(
-        unpickler.unpickle(new TastyUnpickler.TreeSectionUnpickler()).get.unpickle(using Contexts.empty(filename))
-      )
+    args.toList match {
+      case Nil =>
+        // By default, read this project
+        val cl = ClassLoader.getSystemClassLoader
+        val classpath = cl.asInstanceOf[URLClassLoader].getURLs.map(_.getFile).toList
+        val reader = new ProjectReader
+        reader.read(classpath)
+      case "-cp" :: classpath =>
+        val reader = new ProjectReader
+        reader.read(classpath)
+      case "--standalone" :: filename :: Nil =>
+        val unpickler = new TastyUnpickler(Files.readAllBytes(Paths.get(filename)))
+        println(
+          unpickler.unpickle(new TastyUnpickler.TreeSectionUnpickler()).get.unpickle(using Contexts.empty(filename))
+        )
+      case _ =>
+        println("""Two modes of usage:
+                  |--standalone tasty-file
+                  |-cp whitespace-separated-classpath-entries
+                  |By default, will read the current project.""".stripMargin)
     }
 }

--- a/jvm/src/test/scala/BaseUnpicklingSuite.scala
+++ b/jvm/src/test/scala/BaseUnpicklingSuite.scala
@@ -1,5 +1,5 @@
 import tastyquery.Contexts
-import tastyquery.Contexts.Context
+import tastyquery.Contexts.FileContext
 import tastyquery.ast.Trees.Tree
 import tastyquery.ast.Types.Type
 import tastyquery.reader.TastyUnpickler
@@ -9,7 +9,7 @@ import java.nio.file.{Files, Paths}
 abstract class BaseUnpicklingSuite extends munit.FunSuite {
   val ResourceProperty = "test-resources"
 
-  def unpickle(filename: String)(using ctx: Context = Contexts.empty): Tree = {
+  def unpickle(filename: String)(using ctx: FileContext = Contexts.empty(filename)): Tree = {
     val resourcePath = getResourcePath(filename)
     val bytes = Files.readAllBytes(Paths.get(resourcePath))
     val unpickler = new TastyUnpickler(bytes)

--- a/shared/src/main/scala/tastyquery/Contexts.scala
+++ b/shared/src/main/scala/tastyquery/Contexts.scala
@@ -23,7 +23,7 @@ object Contexts {
   }
 
   /** BaseContext is used throughout unpickling an entire project. */
-  class BaseContext private[Contexts](val defn: Definitions) {
+  class BaseContext private[Contexts] (val defn: Definitions) {
     def withFile(filename: String): FileContext =
       new FileContext(defn, defn.RootPackage, filename)
 

--- a/shared/src/main/scala/tastyquery/Contexts.scala
+++ b/shared/src/main/scala/tastyquery/Contexts.scala
@@ -14,16 +14,16 @@ object Contexts {
   /** The current context */
   inline def ctx(using ctx: FileContext): FileContext = ctx
 
-  def empty: ContextBase =
-    new ContextBase(new Definitions())
+  def empty: BaseContext =
+    new BaseContext(new Definitions())
 
   def empty(filename: String): FileContext = {
     val defn = new Definitions()
     new FileContext(defn, defn.RootPackage, filename)
   }
 
-  /** ContextBase is used throughout unpickling an entire project. */
-  class ContextBase private[Contexts] (val defn: Definitions) {
+  /** BaseContext is used throughout unpickling an entire project. */
+  class BaseContext private[Contexts](val defn: Definitions) {
     def withFile(filename: String): FileContext =
       new FileContext(defn, defn.RootPackage, filename)
 
@@ -76,13 +76,13 @@ object Contexts {
   }
 
   /** FileContext is used when unpickling a given .tasty file.
-    * It extends the ContextBase with the information,local to the file, and keeps track of the current owner.
+    * It extends the BaseContext with the information,local to the file, and keeps track of the current owner.
     */
   class FileContext private[Contexts] (
     override val defn: Definitions,
     val owner: Symbol,
     private val fileLocalInfo: FileLocalInfo
-  ) extends ContextBase(defn) {
+  ) extends BaseContext(defn) {
     def this(defn: Definitions, owner: Symbol, filename: String) = this(defn, owner, new FileLocalInfo(filename))
 
     def withEnclosingLambda(addr: Addr, tl: TypeLambda): FileContext =

--- a/shared/src/main/scala/tastyquery/api/ProjectReader.scala
+++ b/shared/src/main/scala/tastyquery/api/ProjectReader.scala
@@ -1,0 +1,56 @@
+package tastyquery.api
+
+import tastyquery.Contexts
+import tastyquery.reader.{TastyUnpickler, TreeUnpickler}
+
+import scala.jdk.CollectionConverters.*
+import java.io.{File, InputStream}
+import java.util.jar.JarFile
+import org.apache.commons.io.IOUtils
+import org.apache.commons.io.FileUtils
+
+class ProjectReader {
+  def read(classpath: List[String]): TastyQuery = {
+    val unpicklingCtx = Contexts.empty
+    classpathToEntries(classpath).map(
+      _.walkTastyFiles(stream => getTreeUnpickler(stream).unpickle(using unpicklingCtx))
+    )
+    new TastyQuery(unpicklingCtx)
+  }
+
+  private def getTreeUnpickler(fileStream: InputStream): TreeUnpickler = {
+    val unpickler = new TastyUnpickler(IOUtils.toByteArray(fileStream))
+    unpickler.unpickle(new TastyUnpickler.TreeSectionUnpickler()).get
+  }
+
+  private def classpathToEntries(classpath: List[String]): List[ClasspathEntry] =
+    // TODO: check isdir
+    classpath.map(e => if (e.endsWith(".jar")) Jar(e) else Directory(e))
+}
+
+sealed abstract class ClasspathEntry(val path: String) {
+  def walkTastyFiles(op: InputStream => Unit): Unit
+}
+
+final case class Jar(override val path: String) extends ClasspathEntry(path) {
+  override def walkTastyFiles(op: InputStream => Unit): Unit = {
+    val jar = JarFile(path)
+    // TODO: a nicer way to force?
+    jar
+      .stream()
+      // force the execution of filter + map on the stream:
+      .iterator()
+      .asScala
+      .toList
+      .filter(je => je.getName().endsWith(".tasty"))
+      .map(je => op(jar.getInputStream(je)))
+  }
+}
+
+final case class Directory(override val path: String) extends ClasspathEntry(path) {
+  override def walkTastyFiles(op: InputStream => Unit): Unit =
+    FileUtils
+      .listFiles(new File(path), Array("tasty"), true)
+      .asScala
+      .map(f => op(FileUtils.openInputStream(f)))
+}

--- a/shared/src/main/scala/tastyquery/api/TastyQuery.scala
+++ b/shared/src/main/scala/tastyquery/api/TastyQuery.scala
@@ -1,8 +1,8 @@
 package tastyquery.api
 
-import tastyquery.Contexts.ContextBase
+import tastyquery.Contexts.BaseContext
 import tastyquery.ast.Trees.Tree
 
 class TastyTrees(trees: List[Tree])
 
-class TastyQuery private[api] (ctx: ContextBase, trees: TastyTrees) {}
+class TastyQuery private[api] (ctx: BaseContext, trees: TastyTrees) {}

--- a/shared/src/main/scala/tastyquery/api/TastyQuery.scala
+++ b/shared/src/main/scala/tastyquery/api/TastyQuery.scala
@@ -1,5 +1,5 @@
 package tastyquery.api
 
-import tastyquery.Contexts.Context
+import tastyquery.Contexts.ContextBase
 
-class TastyQuery private[api] (ctx: Context) {}
+class TastyQuery private[api] (ctx: ContextBase) {}

--- a/shared/src/main/scala/tastyquery/api/TastyQuery.scala
+++ b/shared/src/main/scala/tastyquery/api/TastyQuery.scala
@@ -1,5 +1,8 @@
 package tastyquery.api
 
 import tastyquery.Contexts.ContextBase
+import tastyquery.ast.Trees.Tree
 
-class TastyQuery private[api] (ctx: ContextBase) {}
+class TastyTrees(trees: List[Tree])
+
+class TastyQuery private[api] (ctx: ContextBase, trees: TastyTrees) {}

--- a/shared/src/main/scala/tastyquery/api/TastyQuery.scala
+++ b/shared/src/main/scala/tastyquery/api/TastyQuery.scala
@@ -1,0 +1,5 @@
+package tastyquery.api
+
+import tastyquery.Contexts.Context
+
+class TastyQuery private[api] (ctx: Context) {}


### PR DESCRIPTION
This PR creates a scala 3 project reader, which takes a classpath and runs tree unpickler on all .tasty files on all classpath entries. To accommodate reading a project, two types of context are introduced: project-wide BaseContext and file-local FileContext.